### PR TITLE
feat(macos): simulate copy operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ wry = "0.27.0"
 [target."cfg(target_os = \"linux\")".dependencies]
 x11-clipboard = "0.7.0"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(not(linux))'.dependencies]
 #enigo = "0.0.14"
 enigo = { git = "https://github.com/enigo-rs/enigo" }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -4,16 +4,15 @@ pub fn read_text() -> Result<String, String> {
     use x11_clipboard::Clipboard;
 
     let clipboard = Clipboard::new().unwrap();
-    if let Ok(curr) = clipboard.load(
-        clipboard.getter.atoms.primary,
-        clipboard.getter.atoms.utf8_string,
-        clipboard.getter.atoms.property,
-        Duration::from_millis(100),
-    ) {
-        let curr = String::from_utf8_lossy(&curr)
-            .trim_matches('\u{0}')
-            .trim()
-            .to_string();
+    if
+        let Ok(curr) = clipboard.load(
+            clipboard.getter.atoms.primary,
+            clipboard.getter.atoms.utf8_string,
+            clipboard.getter.atoms.property,
+            Duration::from_millis(100)
+        )
+    {
+        let curr = String::from_utf8_lossy(&curr).trim_matches('\u{0}').trim().to_string();
         if !curr.is_empty() {
             Ok(curr)
         } else {
@@ -26,12 +25,21 @@ pub fn read_text() -> Result<String, String> {
 
 #[cfg(target_os = "macos")]
 pub fn read_text() -> Result<String, String> {
+    use enigo::{ Enigo, Key, KeyboardControllable };
+    // simulate keyboard operation `Command + c`
+    let mut enigo = Enigo::new();
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    enigo.key_down(Key::Command);
+    enigo.key_click(Key::Layout('c'));
+    enigo.key_up(Key::Command);
+
     read_text_cross()
 }
 
 #[cfg(target_os = "windows")]
 pub fn read_text() -> Result<String, String> {
-    use enigo::{Enigo, Key, KeyboardControllable};
+    use enigo::{ Enigo, Key, KeyboardControllable };
     // simulate keyboard operation `Ctrl+c`
     let mut enigo = Enigo::new();
 
@@ -44,7 +52,8 @@ pub fn read_text() -> Result<String, String> {
 }
 
 fn read_text_cross() -> Result<String, String> {
-    wry::application::clipboard::Clipboard::new()
+    wry::application::clipboard::Clipboard
+        ::new()
         .read_text()
         .ok_or("Unsupported clipboard".to_string())
 }


### PR DESCRIPTION
`enigo`这个库是支持macos的，所以我直接复制了windows的实现，只改了`Key`。没有在Mac系统测试!!!